### PR TITLE
support mac os

### DIFF
--- a/lua/webify.lua
+++ b/lua/webify.lua
@@ -50,7 +50,11 @@ end
 
 function open_in_browser(url)
     if url then
-        vim.fn.jobstart({ 'xdg-open', url }, { detach = true })
+        if require('jit').os == 'Linux' then
+            vim.fn.jobstart({ 'xdg-open', url }, { detach = true })
+        else
+            vim.fn.jobstart({ 'open', url }, { detach = true })
+        end
     else
         print('Could not open file')
     end


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds support for opening URLs in the default browser on macOS in addition to Linux.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant open_in_browser
    participant OS
    participant Browser

    User->>open_in_browser: Call with URL
    alt URL exists
        alt Linux OS
            open_in_browser->>OS: Execute xdg-open
            OS->>Browser: Open URL
        else Other OS
            open_in_browser->>OS: Execute open
            OS->>Browser: Open URL
        end
    else URL is nil
        open_in_browser-->>User: Print error message
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/iesahin/webify.nvim/pull/1/files#diff-f484857d6703957407ec7882043a4c52bbf1a4fe2a49d2fbc2536b7425658b92>lua/webify.lua</a></td><td>Modified the <code>open_in_browser</code> function to support opening URLs in the default browser on macOS.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.lua`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->


